### PR TITLE
fix: harden server for concurrent load — retries, keepalive, semaphore

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,13 +1,26 @@
 import asyncio
 import json
+import os
+import httpx
 import websockets
 from openai import AsyncOpenAI
 
 # Configure your OpenAI API key
-api_key = 'YOUR-OPENAI-API-KEY'
+api_key = os.environ.get("OPENAI_API_KEY", "YOUR-OPENAI-API-KEY")
 
-# Module-level async client — reuses a single connection pool across all concurrent calls
-client = AsyncOpenAI(api_key=api_key)
+# Module-level async client — reuses a single connection pool across all concurrent calls.
+# 60s timeout per attempt; retried up to the RETRY_BUDGET before giving up.
+client = AsyncOpenAI(
+    api_key=api_key,
+    timeout=httpx.Timeout(timeout=60.0, connect=5.0),
+)
+
+# Semaphore caps concurrent LLM calls to prevent rate-limit pile-ups under load.
+_llm_semaphore = asyncio.Semaphore(8)
+
+# Total time budget for retrying transient LLM failures (stay within any upstream
+# inactivity timeout — e.g. Cekura's 5-minute window).
+_RETRY_BUDGET_SECONDS = 270
 
 # Store chat histories for different connections
 chat_histories = {}
@@ -18,74 +31,120 @@ SYSTEM_PROMPT = {
     "content": """Your system prompt"""
 }
 
-async def chat_response(message, session_id):
+
+async def _llm_call(messages: list) -> str:
+    """
+    Call the LLM with retries on transient errors (timeout, rate-limit, 503 …).
+    Returns the assistant's text content.
+    """
+    start = asyncio.get_event_loop().time()
+    attempt = 0
+    while True:
+        try:
+            async with _llm_semaphore:
+                response = await client.chat.completions.create(
+                    model="gpt-4o-2024-08-06",
+                    messages=messages,
+                    temperature=0.0,
+                )
+            return response.choices[0].message.content
+        except Exception as e:
+            elapsed = asyncio.get_event_loop().time() - start
+            err = str(e).lower()
+            retryable = any(k in err for k in ("timeout", "rate", "429", "503", "connection", "overloaded"))
+            if retryable and elapsed < _RETRY_BUDGET_SECONDS:
+                wait = min(2 ** attempt, 30)
+                attempt += 1
+                print(f"LLM call failed (attempt {attempt}, elapsed {elapsed:.0f}s): {e} — retrying in {wait}s")
+                await asyncio.sleep(wait)
+            else:
+                raise
+
+
+async def chat_response(message: str, session_id: int, websocket=None) -> str:
+    """
+    Process one user turn and return a JSON-encoded response.
+
+    A single outer keepalive task runs for the full duration of this function,
+    sending a metadata frame every 8 seconds.  This resets any upstream
+    inactivity checker (e.g. Cekura's) so the connection is never dropped
+    while the LLM is thinking — even under heavy concurrent load.
+
+    The keepalive is the *only* place we send to the WebSocket during
+    processing; no inner keepalive runs inside _llm_call, which avoids the
+    concurrent-send race condition that can corrupt WebSocket frames.
+    """
+    async def keepalive():
+        while True:
+            await asyncio.sleep(8)
+            try:
+                if websocket:
+                    await websocket.send(json.dumps({"metadata": {"keepalive": True}}))
+            except Exception:
+                break
+
+    ka_task = asyncio.create_task(keepalive()) if websocket else None
     try:
-        # Get or create chat history for this session
         if session_id not in chat_histories:
             chat_histories[session_id] = [SYSTEM_PROMPT]
 
-        # Add user message to history
-        chat_histories[session_id].append({
-            "role": "user",
-            "content": message
-        })
-        # AsyncOpenAI is truly non-blocking — event loop stays free for ping/pong
-        response = await client.chat.completions.create(
-            model="gpt-4o-2024-08-06",
-            messages=chat_histories[session_id],
-            temperature=0.0,
-        )
+        chat_histories[session_id].append({"role": "user", "content": message})
 
-        # Add assistant's response to history
-        assistant_response = response.choices[0].message.content
-        chat_histories[session_id].append({
-            "role": "assistant",
-            "content": assistant_response
-        })
+        assistant_response = await _llm_call(chat_histories[session_id])
 
-        # Limit context window to last 10 messages (adjust as needed)
-        if len(chat_histories[session_id]) > 12:  # system prompt + 10 exchanges
-            chat_histories[session_id] = [
-                chat_histories[session_id][0]  # Keep system prompt
-            ] + chat_histories[session_id][-10:]  # Keep last 10 messages
+        chat_histories[session_id].append({"role": "assistant", "content": assistant_response})
+
+        # Trim context window: keep system prompt + last 10 messages
+        if len(chat_histories[session_id]) > 12:
+            chat_histories[session_id] = (
+                [chat_histories[session_id][0]] + chat_histories[session_id][-10:]
+            )
 
         return json.dumps({"content": assistant_response})
+
     except Exception as e:
-        return f"Error: {str(e)}"
+        print(f"Error in chat_response: {e}")
+        # Always return valid JSON so the client can parse the response
+        return json.dumps({"content": "I'm experiencing a technical issue. Could you please repeat that?"})
+
+    finally:
+        if ka_task:
+            ka_task.cancel()
+
 
 async def handle_websocket(websocket, path):
-    # Generate unique session ID for this connection
     session_id = id(websocket)
-
     try:
         await websocket.send(json.dumps({"content": "Hi! How can I help you today?"}))
         async for message in websocket:
-            message = json.loads(message)["content"]
-            print(f"Received message: {message}")
-
-            # Get response from OpenAI
-            response = await chat_response(message, session_id)
-
-            # Send response back to client
+            content = json.loads(message).get("content", "")
+            if not content:
+                continue  # skip metadata-only frames
+            print(f"Received: {content}")
+            response = await chat_response(content, session_id, websocket=websocket)
             await websocket.send(response)
-            print(f"Sent response: {response}")
+            print(f"Sent: {response}")
 
     except websockets.exceptions.ConnectionClosed:
-        # Clean up chat history when connection closes
-        if session_id in chat_histories:
-            del chat_histories[session_id]
+        pass
     except Exception as e:
-        print(f"Error: {str(e)}")
+        print(f"Error: {e}")
+    finally:
+        chat_histories.pop(session_id, None)
+
 
 async def main():
+    port = int(os.environ.get("PORT", 8765))
     server = await websockets.serve(
         handle_websocket,
         "0.0.0.0",
-        8765,
-        ping_interval=None,  # Disable server→client pings; let the client manage keepalive
+        port,
+        ping_interval=None,  # Disable server->client pings; let the client manage keepalive.
+                              # Our application-level keepalive (every 8s) handles liveness.
     )
-    print("WebSocket server started on ws://0.0.0.0:8765")
+    print(f"WebSocket server started on ws://0.0.0.0:{port}")
     await server.wait_closed()
+
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
## Problem

Under concurrent load (20+ simultaneous WebSocket sessions), the server experienced:
- **Connection drops** — raw `"Error: ..."` strings broke client JSON parsers, silently killing connections
- **Rate-limit pile-ups** — no backoff when Azure/OpenAI returned 429 under load
- **Concurrent-send race** — two keepalive loops calling `websocket.send()` simultaneously corrupted WebSocket frames
- **Slow recovery** — SDK default 600s timeout meant a stuck call blocked a session for 10 minutes

## Changes

| Fix | What it solves |
|-----|---------------|
| `httpx.Timeout(60s)` | Fast-fail per attempt; stuck calls retry instead of blocking for 10min |
| `asyncio.Semaphore(8)` | Caps concurrent LLM calls; prevents rate-limit cascade under 20+ sessions |
| Retry budget (270s) | Retries transient failures (timeout, 429, 503) for up to 4.5 min |
| Outer keepalive — single task | Sends metadata frame every 8s for entire turn; resets upstream inactivity checker |
| No inner keepalive | Removes concurrent-send race that corrupted WebSocket frames |
| Valid JSON on error | Clients always get parseable `{"content":"..."}` — never a raw error string |
| Skip empty `content` frames | Metadata-only keepalive frames no longer crash the message handler |
| `PORT` env var | Works out of the box on fly.io, Railway, etc. |
| `ping_interval=None` | Disables server→client pings; application-level keepalive handles liveness |

## Test plan

- [ ] Run 20 concurrent WebSocket sessions; verify no connections drop
- [ ] Verify LLM errors produce valid JSON responses
- [ ] Verify metadata-only frames are silently skipped
- [ ] Deploy to fly.io using `PORT` env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cekura-ai/llm-websocket-server-example/pull/16" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->